### PR TITLE
Docs/updated example

### DIFF
--- a/example/README
+++ b/example/README
@@ -1,19 +1,21 @@
-settings.py
+######################
+# Configure setup.py #
+######################
 
 Find and edit the lines marked with # <-- EDIT
 
 
-####################
-# Setup virtualenv #
-####################
+######################
+#  Setup virtualenv  #
+######################
 
 virtualenv .
 source bin/activate
 pip install -r requirements.txt
 
-####################
-#  Setup manually  #
-####################
+######################
+#   Setup manually   #
+######################
 
 Modules you'll need available:
 

--- a/example/README
+++ b/example/README
@@ -2,13 +2,29 @@ settings.py
 
 Find and edit the lines marked with # <-- EDIT
 
+
+####################
+# Setup virtualenv #
+####################
+
+virtualenv .
+source bin/activate
+pip install -r requirements.txt
+
+####################
+#  Setup manually  #
+####################
+
 Modules you'll need available:
 
 Django 1.3
-Django CMS 2.13
+Django CMS 2.1.3
 pyquery 0.6.1
-typogrify
-easy_thumbnailss
+django-typogrify
+easy_thumbnails
+django-celery
+django_polymorphic
+
 also:
 
 https://github.com/stefanfoulis/django-filer

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,0 +1,15 @@
+Django >= 1.3
+django-cms
+pyquery == 0.6.1
+django-typogrify
+easy_thumbnails
+BeautifulSoup >= 3.0.8.1
+django-classy-tags
+django-filer
+django-appmedia
+django-celery
+django_polymorphic
+
+-e git+git://github.com/evildmp/django-filer.git@video#egg=django-filer-video
+-e hg+https://bitbucket.org/evildmp/semanticeditor#egg=semanticeditor
+-e git+git://github.com/evildmp/django-widgetry.git#egg=django-widgetry

--- a/example/settings.py
+++ b/example/settings.py
@@ -3,6 +3,10 @@
 import os
 import os.path
 
+# Make it work straight from the checkout!
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '../'))
+
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
@@ -151,15 +155,17 @@ TEMPLATE_DIRS = (
 )
 
 # ------------------------ Django Celery
+try:
+    import djcelery
+    djcelery.setup_loader()
 
-import djcelery
-djcelery.setup_loader()
-
-BROKER_HOST = "localhost"
-BROKER_PORT = 5672
-BROKER_USER = "guest"
-BROKER_PASSWORD = "guest"
-BROKER_VHOST = "/"
+    BROKER_HOST = "localhost"
+    BROKER_PORT = 5672
+    BROKER_USER = "guest"
+    BROKER_PASSWORD = "guest"
+    BROKER_VHOST = "/"
+except ImportError:
+    pass
 
 
 # ------------------------ Django CMS


### PR DESCRIPTION
Updated the documentation in the example project and made a little script thats injected in settings.py, that appends the parent directory to the path, so that you dont have to do any custom magic or symlinks to run the code directly from the git checkout itself.

Furthermore i added a requirements.txt which contains all the correct versions of the 3rd party software to run the example application. It should now be possible to run the example project in a one-liner with something like:

cd example/ && virtualenv . && source bin/activate && pip install -r requirements.txt && python manage.py syncdb --noinput && python manage.py reset contenttypes && python manage.py loaddata example_database.json && python manage.py runserver
