### PR TITLE
Set correct version of easy_thumbnails in examples/requirements.txt

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -2,7 +2,7 @@ Django >= 1.3
 django-cms
 pyquery == 0.6.1
 django-typogrify
-easy_thumbnails
+easy_thumbnails==1.0-alpha-16
 BeautifulSoup >= 3.0.8.1
 django-classy-tags
 django-filer


### PR DESCRIPTION
If we don't do this we get error messages from django-filer-video.
