### PR TITLE
Url patterns (re)defined only in urls.py

### DIFF
--- a/arkestra_utilities/mixins.py
+++ b/arkestra_utilities/mixins.py
@@ -21,6 +21,8 @@ class URLModelMixin(models.Model):
     def get_absolute_url(self):
         if self.external_url:
             return self.external_url.url
+        elif self.url_path in ["news","event","vacancy","studentship"]:
+            return reverse(self.url_path,kwargs={"slug":self.slug})
         else:
             return "/%s/%s/" % (self.url_path, self.slug)
 

--- a/contacts_and_people/models.py
+++ b/contacts_and_people/models.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import User
 from django.template.defaultfilters import slugify
 from django.conf import settings
-
+from django.core.urlresolvers import reverse
 from cms.models import Page, CMSPlugin
 from cms.models.fields import PlaceholderField
 
@@ -98,7 +98,7 @@ class Building(models.Model):
         return building_identifier
     
     def get_absolute_url(self):
-        return "/place/%s/" % self.slug
+        return reverse("contact_place", kwargs={"slug":self.slug}) 
     
     def save(self):
         if not self.slug or self.slug == '':
@@ -317,9 +317,9 @@ class Entity(MPTTModel, EntityLite, CommonFields):
         if self.external_url:
             return self.external_url.url
         elif self.get_website:
-            return "/contact/%s/" % self.slug
+            return reverse("contact", kwargs={"slug":self.slug}) 
         else:
-            return "/contact/"
+            return reverse("contact_base") 
 
     @property
     def _get_real_ancestor(self):
@@ -412,12 +412,20 @@ class Entity(MPTTModel, EntityLite, CommonFields):
         
         If the entity is the base entity, doesn't add the entity slug to the URL
         """
+        kinds = ["contact","news-and-events","vacancies-and-studentships","forthcoming-events","news-archive","previous-events"] # "publications"
         if self.external_url:
             return ""
         elif self == Entity.objects.base_entity():
-            return "/%s/" % kind
+            if kind in kinds:
+                url = reverse(kind+"_base")
+            else:
+                url = "/%s/" % kind
         else:
-            return "/%s/%s/" % (kind, self.slug)
+            if kind in kinds:
+                reverse(kind,kwargs={"slug":self.slug})
+            else:
+                url = "/%s/%s/" % (kind, self.slug)
+        return url
 
     def get_template(self):
         """
@@ -595,7 +603,7 @@ class Person(PersonLite, CommonFields):
         if self.external_url:
             return self.external_url.url
         else:
-            return "/person/%s/" % self.slug
+            return reverse("contact_person", kwargs={"slug":self.slug}) 
 
     @property
     def get_role(self):

--- a/contacts_and_people/urls.py
+++ b/contacts_and_people/urls.py
@@ -1,20 +1,22 @@
 from django.conf.urls.defaults import patterns, include, url
 
-urlpatterns = patterns('',
+urlpatterns = patterns('contacts_and_people.views',
 
     # person
-    (r"^person/(?P<slug>[-\w]+)/(?P<active_tab>[-\w]*)/?$", "contacts_and_people.views.person"),
+    (r"^person/(?P<slug>[-\w]+)/?$", "person", {}, "contact_person"),
+    (r"^person/(?P<slug>[-\w]+)/(?P<active_tab>[-\w]*)/?$", "person", {}, "contact_person_tab"),
     
     # place
-    (r"^place/(?P<slug>[-\w]+)/(?P<active_tab>[-\w]*)/?$", "contacts_and_people.views.place"),    
+    (r"^place/(?P<slug>[-\w]+)/?$", "place", {}, "contact_place"),    
+    (r"^place/(?P<slug>[-\w]+)/(?P<active_tab>[-\w]*)/?$", "place", {}, "contact_place_tab"),    
 
     # lists of people in an entity
-    (r"^people/(?P<slug>[-\w]+)/(?P<letter>\w)/$", "contacts_and_people.views.people"),
-    (r"^people/(?P<slug>[-\w]+)/$", "contacts_and_people.views.people"), 
+    (r"^people/(?P<slug>[-\w]+)/$", "people", {}, "contact_people"), 
+    (r"^people/(?P<slug>[-\w]+)/(?P<letter>\w)/$", "people", {}, "contact_people_letter"),
     
     # main contacts & people page
-    (r'^contact/(?P<slug>[-\w]+)/$', "contacts_and_people.views.contacts_and_people"), # non-base entities
-    (r'^contact/$', "contacts_and_people.views.contacts_and_people"), # base entity only
+    (r'^contact/(?P<slug>[-\w]+)/$', "contacts_and_people", {}, "contact"), # non-base entities
+    (r'^contact/$', "contacts_and_people", {}, "contact_base"), # base entity only
 
     # news, events, vacancies, studentships
     (r'^', include('news_and_events.urls')),

--- a/news_and_events/urls.py
+++ b/news_and_events/urls.py
@@ -1,18 +1,21 @@
 from django.conf.urls.defaults import *
-from news_and_events import views
 # from  news_and_events.views import NewsAndEventsViews
 
-urlpatterns = patterns('',
+urlpatterns = patterns('news_and_events.views',
     
     # news and events items
-    url(r"^news/(?P<slug>[-\w]+)/$", views.newsarticle, name="newsarticle"),
-    url(r"^event/(?P<slug>[-\w]+)/$", views.event, name="event"),
+    url(r"^news/(?P<slug>[-\w]+)/$", "newsarticle", {}, "news" ),
+    url(r"^event/(?P<slug>[-\w]+)/$", "event", {}, "event"),
     
     # named entities' news and events
-    url(r'^news-archive/(?:(?P<slug>[-\w]+)/)?$', views.news_archive, name="news_archive"),
-    url(r'^previous-events/(?:(?P<slug>[-\w]+)/)?$', views.previous_events, name="previous_events"),
-    url(r'^forthcoming-events/(?:(?P<slug>[-\w]+)/)?$', views.all_forthcoming_events, name="forthcoming_event"),
-    url(r"^news-and-events/(?:(?P<slug>[-\w]+)/)?$", views.news_and_events, name="news_and_events"),
+    url(r'^news-archive/?$', "news_archive", {}, "news-archive_base"),
+    url(r'^news-archive/(?:(?P<slug>[-\w]+)/)?$', "news_archive", {}, "news-archive"),
+    url(r'^previous-events/?$', "previous_events", {}, "previous-events_base"),
+    url(r'^previous-events/(?:(?P<slug>[-\w]+)/)?$', "previous_events", {}, "previous-events"),
+    url(r'^forthcoming-events/?$', "all_forthcoming_events", {}, "forthcoming-events_base"),
+    url(r'^forthcoming-events/(?:(?P<slug>[-\w]+)/)?$', "all_forthcoming_events", {}, "forthcoming-events"),
+    url(r"^news-and-events/?$", "news_and_events", {}, "news-and-events_base"),
+    url(r"^news-and-events/(?:(?P<slug>[-\w]+)/)?$", "news_and_events", {}, "news-and-events"),
     )
     #(r"^entity/(?P<slug>[-\w]+)/news/$", "news_and_events.views.news"), # in development
 

--- a/news_and_events/views.py
+++ b/news_and_events/views.py
@@ -1,5 +1,5 @@
 import datetime
-
+from django.utils.translation import ugettext as _
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext
 from django.http import Http404
@@ -39,17 +39,17 @@ def common_settings(request, slug):
     return instance, context, entity
 
 
-def news_and_events(request, slug):
+def news_and_events(request, slug=None):
     instance, context, entity = common_settings(request, slug)    
 
     instance.type = "main_page"
 
     meta = {"description": "Recent news and forthcoming events",}
-    title = unicode(entity) + u" news & events"
+    title = unicode(entity) + _(u" news & events")
     if MULTIPLE_ENTITY_MODE:
-        pagetitle = unicode(entity) + u" news & events"
+        pagetitle = unicode(entity) + _(u" news & events")
     else:
-        pagetitle = "News & events"
+        pagetitle = _("News & events")
     CMSNewsAndEventsPlugin().render(context, instance, None)
     
     context.update({

--- a/vacancies_and_studentships/urls.py
+++ b/vacancies_and_studentships/urls.py
@@ -1,26 +1,25 @@
 from django.conf.urls.defaults import patterns
 
-urlpatterns = patterns('',
+urlpatterns = patterns('vacancies_and_studentships.views',
     
     # vacancies and studentships 
-    (r"^vacancy/(?P<slug>[-\w]+)/$", "vacancies_and_studentships.views.vacancy"),
-    (r"^studentship/(?P<slug>[-\w]+)/$", "vacancies_and_studentships.views.studentship"),
+    (r"^vacancy/(?P<slug>[-\w]+)/$", "vacancy", {}, "vacancy"),
+    (r"^studentship/(?P<slug>[-\w]+)/$", "studentship", {}, "studentship"),
     
     # named entities' vacancies and studentships
-    (r"^vacancies-and-studentships/(?P<slug>[-\w]+)/$", "vacancies_and_studentships.views.vacancies_and_studentships"),
-
-    (r'^archived-vacancies/(?P<slug>[-\w]+)/$', "vacancies_and_studentships.views.archived_vacancies"),
-    (r'^all-open-vacancies/(?P<slug>[-\w]+)/$', "vacancies_and_studentships.views.all_current_vacancies"),
-
-    (r'^archived-studentships/(?P<slug>[-\w]+)/$', "vacancies_and_studentships.views.archived_studentships"),
-    (r'^all-open-studentships/(?P<slug>[-\w]+)/$', "vacancies_and_studentships.views.all_current_studentships"),
-
+    (r"^vacancies-and-studentships/(?P<slug>[-\w]+)/$", "vacancies_and_studentships", {}, "vacancies-and-studentships"),
     # base entity's vacancies and studentships
-    (r'^vacancies-and-studentships/$', "vacancies_and_studentships.views.vacancies_and_studentships"),
-    
-    (r'^archived-vacancies/$', "vacancies_and_studentships.views.archived_vacancies"),
-    (r'^all-open-vacancies/$', "vacancies_and_studentships.views.all_current_vacancies"),
+    (r'^vacancies-and-studentships/$', "vacancies_and_studentships", {}, "vacancies-and-studentships_base"),
 
-    (r'^archived-studentships/$', "vacancies_and_studentships.views.archived_studentships"),
-    (r'^all-open-studentships/$', "vacancies_and_studentships.views.all_current_studentships"),
+    (r'^archived-vacancies/(?P<slug>[-\w]+)/$', "archived_vacancies"),
+    (r'^all-open-vacancies/(?P<slug>[-\w]+)/$', "all_current_vacancies"),
+    
+    (r'^archived-vacancies/$', "archived_vacancies"),
+    (r'^all-open-vacancies/$', "all_current_vacancies"),
+
+    (r'^archived-studentships/(?P<slug>[-\w]+)/$', "archived_studentships"),
+    (r'^all-open-studentships/(?P<slug>[-\w]+)/$', "all_current_studentships"),
+
+    (r'^archived-studentships/$', "archived_studentships"),
+    (r'^all-open-studentships/$', "all_current_studentships"),
 )


### PR DESCRIPTION
Urls for contacts, news and vacancies were defined in multiple places: 
- `urls.py`, 
- `models.py` - in `url_path` and 
- `menus.py` - in `url_attribute`. 

This situation prevents changing/translating the default urls (i.e. contacts/ news/ etc). In this commit url patterns in `urls.py` are given names and then `reverse` is used to resolve urls where needed i.e. in  `Entity.get_related_info_page_url` or in `URLModelMixin.get_absolute_url`. 

Url patterns are named so that their name can be deduced from  `url_path` and `url_attribute` when needed.
