### PR TITLE
News & Events, Vacancies & Studentships urls, views and tests improved

### DIFF
--- a/news_and_events/admin.py
+++ b/news_and_events/admin.py
@@ -32,8 +32,8 @@ class NewsAndEventsAdmin(GenericModelAdmin):
     prepopulated_fields = {
         'slug': ('title',)
             }
-    list_max_show_all = 400
-    list_per_page = 400
+    list_max_show_all = 1000
+    list_per_page = 1000
         
     def _media(self):
         return super(ModelAdminWithTabsAndCMSPlaceholder, self).media

--- a/news_and_events/urls.py
+++ b/news_and_events/urls.py
@@ -8,7 +8,7 @@ urlpatterns = patterns('',
     url(r"^news/(?P<slug>[-\w]+)/$", views.newsarticle, name="newsarticle"),
     url(r"^event/(?P<slug>[-\w]+)/$", views.event, name="event"),
     
-    # named entities' news and events
+    # entities' news and events
     url(r'^news-archive/(?:(?P<slug>[-\w]+)/)?$', views.news_archive, name="news_archive"),
     url(r'^previous-events/(?:(?P<slug>[-\w]+)/)?$', views.previous_events, name="previous_events"),
     url(r'^forthcoming-events/(?:(?P<slug>[-\w]+)/)?$', views.all_forthcoming_events, name="forthcoming_event"),

--- a/news_and_events/views.py
+++ b/news_and_events/views.py
@@ -5,7 +5,6 @@ from django.template import RequestContext
 from django.http import Http404
 
 from contacts_and_people.models import Entity
-from links.link_functions import object_links
 
 from models import NewsAndEventsPlugin, Event, NewsArticle
 from cms_plugins import CMSNewsAndEventsPlugin
@@ -15,12 +14,12 @@ from arkestra_utilities.settings import NEWS_AND_EVENTS_LAYOUT, MAIN_NEWS_EVENTS
 
 def common_settings(request, slug):
     if slug:
-        try:
-            entity = Entity.objects.get(slug=slug)
-        except Entity.DoesNotExist:
-            raise Http404   
+        entity = get_object_or_404(Entity, slug=slug)
     else:
         entity = Entity.objects.base_entity()
+    if not (entity.website and entity.website.published and entity.auto_news_page):
+        raise Http404 
+
     request.auto_page_url = request.path
     # request.path = entity.get_website.get_absolute_url() # for the menu, so it knows where we are
     request.current_page = entity.get_website
@@ -51,7 +50,7 @@ def news_and_events(request, slug):
     else:
         pagetitle = "News & events"
     CMSNewsAndEventsPlugin().render(context, instance, None)
-    
+
     context.update({
         "entity":entity,
         "title": title,
@@ -62,7 +61,7 @@ def news_and_events(request, slug):
         'everything': instance,
         }
         )
-    
+
     return render_to_response(
         "contacts_and_people/arkestra_page.html",
         context,
@@ -170,7 +169,7 @@ def newsarticle(request, slug):
         "meta": {"description": newsarticle.summary,}
         },
         RequestContext(request),
-        )
+    )
 
 def event(request, slug):
     """

--- a/vacancies_and_studentships/tests.py
+++ b/vacancies_and_studentships/tests.py
@@ -1,0 +1,322 @@
+from django.test import TestCase
+from django.test.client import Client
+from django.test.utils import override_settings
+
+from django.conf import settings
+from django.contrib.auth.models import User
+
+# we're testing the behaviour of a method that uses date-related functions
+import datetime
+
+from cms.api import create_page
+
+from models import Vacancy
+from contacts_and_people.models import Entity
+
+class VacanciesTests(TestCase):
+    def setUp(self):
+        # Every test needs a client.
+        self.client = Client()
+        
+        self.toothjob = Vacancy(
+            title = "Pulling teeth",
+            slug = "pulling-teeth",
+            closing_date = datetime.datetime.now() + datetime.timedelta(days=30),
+            )
+
+    def test_generic_attributes(self):
+        self.toothjob.save()
+        # the item has no informative content
+        self.assertEqual(self.toothjob.is_uninformative, True)
+        
+        # there are no Entities in the database, so this can't be hosted_by anything
+        self.assertEqual(self.toothjob.hosted_by, None)
+
+        # since there are no Entities in the database, default to settings's template
+        self.assertEqual(self.toothjob.get_template, settings.CMS_TEMPLATES[0][0])
+
+    def test_date_related_attributes(self):
+        self.toothjob.closing_date = datetime.datetime(year=2012, month=12, day=12)
+        self.assertEqual(self.toothjob.get_when, "December 2012")
+            
+@override_settings(
+    CMS_TEMPLATES = (('null.html', "Null"),)
+)
+class VacanciesStudentshipsItemsViewsTests(TestCase):
+    def setUp(self):
+        # Every test needs a client.
+        self.client = Client()
+        
+        # create a vacancy item
+        self.toothjob = Vacancy(
+            title = "Pulling teeth",
+            slug = "pulling-teeth",
+            closing_date = datetime.datetime.now() + datetime.timedelta(days=30),
+            )
+        
+        self.adminuser = User.objects.create_user('arkestra', 'arkestra@example.com', 'arkestra')
+        self.adminuser.is_staff=True
+        self.adminuser.save()
+
+    # vacancy tests
+    def test_unpublished_vacancy_404(self):
+        self.toothjob.save()
+        
+        # Issue a GET request.
+        response = self.client.get('/vacancy/pulling-teeth/')  
+
+        # Check that the response is 404 because it's not published
+        self.assertEqual(response.status_code, 404)
+
+    def test_unpublished_vacancy_200_for_admin(self):
+        self.toothjob.save()
+
+        # log in a staff user
+        self.client.login(username='arkestra', password='arkestra')        
+        response = self.client.get('/vacancy/pulling-teeth/')  
+        self.assertEqual(response.status_code, 200)
+        
+    def test_published_vacancy_200_for_everyone(self):
+        self.toothjob.published = True
+        self.toothjob.save()
+                
+        # Check that the response is 200 OK.
+        response = self.client.get('/vacancy/pulling-teeth/')  
+        self.assertEqual(response.status_code, 200)
+
+    def test_published_vacancy_context(self):
+        self.toothjob.published = True
+        self.toothjob.save()
+        response = self.client.get('/vacancy/pulling-teeth/')  
+        self.assertEqual(response.context['vacancy'], self.toothjob)
+    
+@override_settings(
+    CMS_TEMPLATES = (('null.html', "Null"),)
+)
+class VacanciesStudentshipsEntityPagesViewsTests(TestCase):
+    def setUp(self):
+        # Every test needs a client.
+        self.client = Client()
+        
+        home_page = create_page(
+            "School home page", 
+            "null.html", 
+            "en",
+            published=True
+            )
+
+        self.school = Entity(
+            name="School of Medicine", 
+            slug="medicine",
+            auto_vacancies_page=True,
+            website=home_page
+            )
+
+
+    # entity vacancies and studentships URLs - has vacancies and studentships pages
+    def test_vacancies_and_studentships_main_url(self):
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_vacancies_and_studentships_entity_url(self):
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/medicine/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_vacancies_and_studentships_bogus_entity_url(self):
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/xxxx/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_main_archive_url(self):
+        self.school.save()
+        response = self.client.get('/archived-vacancies/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_vacancies_and_studentships_entity_vacancies_archive_url(self):
+        self.school.save()
+        response = self.client.get('/archived-vacancies/medicine/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_vacancies_and_studentships_bogus_entity_vacancies_archive_url(self):
+        self.school.save()
+        response = self.client.get('/archived-vacancies/xxxx/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_main_archived_studentships_url(self):
+        self.school.save()
+        response = self.client.get('/archived-studentships/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_vacancies_and_studentships_entity_archived_studentships_url(self):
+        self.school.save()
+        response = self.client.get('/archived-studentships/medicine/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_vacancies_and_studentships_bogus_entity_archived_studentships_url(self):
+        self.school.save()
+        response = self.client.get('/archived-studentships/xxxx/')
+        self.assertEqual(response.status_code, 404)
+        
+    def test_vacancies_and_studentships_main_all_current_studentships_url(self):
+        self.school.save()
+        response = self.client.get('/all-open-studentships/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_vacancies_and_studentships_entity_all_current_studentships_url(self):
+        self.school.save()
+        response = self.client.get('/all-open-studentships/medicine/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_vacancies_and_studentships_bogus_entity_all_current_studentships_url(self):
+        self.school.save()
+        response = self.client.get('/all-open-studentships/xxx/')
+        self.assertEqual(response.status_code, 404)
+
+    # entity vacancies and studentships URLs - no vacancies and studentships pages
+    def test_vacancies_and_studentships_no_auto_page_main_url(self):
+        self.school.auto_vacancies_page = False
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_entity_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/medicine/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_bogus_entity_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/xxxx/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_main_archive_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/vacancies-archive/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_entity_vacancies_archive_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/vacancies-archive/medicine/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_bogus_entity_vacancies_archive_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/vacancies-archive/xxxx/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_main_archived_studentships_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/archived-studentships/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_entity_archived_studentships_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/archived-studentships/medicine/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_bogus_entity_archived_studentships_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/archived-studentships/xxxx/')
+        self.assertEqual(response.status_code, 404)
+        
+    def test_vacancies_and_studentships_no_auto_page_main_all_current_studentships_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/all-open-studentships/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_entity_all_current_studentships_url(self):
+        self.school.auto_vacancies_page = False
+        self.school.save()
+        response = self.client.get('/all-open-studentships/medicine/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_auto_page_bogus_entity_all_current_studentships_url(self):
+        self.school.auto_vacancies_page= False
+        self.school.save()
+        response = self.client.get('/all-open-studentships/xxx/')
+        self.assertEqual(response.status_code, 404)
+
+    # entity vacancies and studentships URLs - no entity home page
+    def test_vacancies_and_studentships_no_entity_home_page_main_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_entity_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/medicine/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_bogus_entity_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/vacancies-and-studentships/xxxx/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_main_archive_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/vacancies-archive/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_entity_vacancies_archive_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/vacancies-archive/medicine/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_bogus_entity_vacancies_archive_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/vacancies-archive/xxxx/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_main_archived_studentships_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/archived-studentships/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_entity_archived_studentships_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/archived-studentships/medicine/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_bogus_entity_archived_studentships_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/archived-studentships/xxxx/')
+        self.assertEqual(response.status_code, 404)
+        
+    def test_vacancies_and_studentships_no_entity_home_page_main_all_current_studentships_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/all-open-studentships/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_entity_all_current_studentships_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/all-open-studentships/medicine/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_vacancies_and_studentships_no_entity_home_page_bogus_entity_all_current_studentships_url(self):
+        self.school.website = None
+        self.school.save()
+        response = self.client.get('/all-open-studentships/xxx/')
+        self.assertEqual(response.status_code, 404)
+

--- a/vacancies_and_studentships/urls.py
+++ b/vacancies_and_studentships/urls.py
@@ -1,26 +1,17 @@
-from django.conf.urls.defaults import patterns
+from django.conf.urls.defaults import patterns, url
+import views
 
 urlpatterns = patterns('',
     
-    # vacancies and studentships 
-    (r"^vacancy/(?P<slug>[-\w]+)/$", "vacancies_and_studentships.views.vacancy"),
-    (r"^studentship/(?P<slug>[-\w]+)/$", "vacancies_and_studentships.views.studentship"),
+    # vacancies and studentships items
+    url(r"^vacancy/(?P<slug>[-\w]+)/$", views.vacancy, name="vacancy"),
+    url(r"^studentship/(?P<slug>[-\w]+)/$", views.studentship, name="studentship"),
     
-    # named entities' vacancies and studentships
-    (r"^vacancies-and-studentships/(?P<slug>[-\w]+)/$", "vacancies_and_studentships.views.vacancies_and_studentships"),
-
-    (r'^archived-vacancies/(?P<slug>[-\w]+)/$', "vacancies_and_studentships.views.archived_vacancies"),
-    (r'^all-open-vacancies/(?P<slug>[-\w]+)/$', "vacancies_and_studentships.views.all_current_vacancies"),
-
-    (r'^archived-studentships/(?P<slug>[-\w]+)/$', "vacancies_and_studentships.views.archived_studentships"),
-    (r'^all-open-studentships/(?P<slug>[-\w]+)/$', "vacancies_and_studentships.views.all_current_studentships"),
-
-    # base entity's vacancies and studentships
-    (r'^vacancies-and-studentships/$', "vacancies_and_studentships.views.vacancies_and_studentships"),
+    # entities' vacancies and studentships
+    url(r'^archived-vacancies/(?:(?P<slug>[-\w]+)/)?$', views.archived_vacancies, name="archived_vacancies"),
+    url(r'^all-open-vacancies/(?:(?P<slug>[-\w]+)/)?$', views.all_current_vacancies, name="all_current_vacancies"),
+    url(r'^archived-studentships/(?:(?P<slug>[-\w]+)/)?$', views.vacancies_and_studentships, name="vacancies_and_studentships"),
+    url(r"^all-open-studentships/(?:(?P<slug>[-\w]+)/)?$", views.all_current_studentships, name="all_current_studentships"),
+    url(r"^vacancies-and-studentships/(?:(?P<slug>[-\w]+)/)?$", views.vacancies_and_studentships, name="vacancies_and_studentships"),
+    )
     
-    (r'^archived-vacancies/$', "vacancies_and_studentships.views.archived_vacancies"),
-    (r'^all-open-vacancies/$', "vacancies_and_studentships.views.all_current_vacancies"),
-
-    (r'^archived-studentships/$', "vacancies_and_studentships.views.archived_studentships"),
-    (r'^all-open-studentships/$', "vacancies_and_studentships.views.all_current_studentships"),
-)


### PR DESCRIPTION
- longer list in NewsArticle/Events admin
- news/events/vacancies/studentships views now check for:
  - auto page
  - existence and publishing status of Entity.website
- vacancies_and_studentships.views and urls brought into line with news_and_events.views
- more tests
